### PR TITLE
Timediff substraction bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@ from setuptools import setup
 from setuptools import find_packages
 
 REQUIREMENTS = [
-  "thumbor==5.0.3",
-  "gcloud==0.7.1",
-  "protorpc==0.10.0",
+  "thumbor==5.2.1",
+  "gcloud==0.12.0",
+  "protorpc==0.11.1",
+  "oauth2client==2.0.1",
 ]
 
 setup(

--- a/thumbor_cloud_storage/loaders/cloud_storage_loader.py
+++ b/thumbor_cloud_storage/loaders/cloud_storage_loader.py
@@ -1,6 +1,7 @@
 from tornado.concurrent import return_future
 from gcloud import storage
 from collections import defaultdict
+from oauth2client.service_account import ServiceAccountCredentials
 
 buckets = defaultdict(dict)
 
@@ -8,9 +9,11 @@ buckets = defaultdict(dict)
 def load(context, path, callback):
     bucket_id  = context.config.get("CLOUD_STORAGE_BUCKET_ID")
     project_id = context.config.get("CLOUD_STORAGE_PROJECT_ID")
+    auth_json = context.config.get("CLOUD_STORAGE_AUTH_JSON")
     bucket = buckets[project_id].get(bucket_id, None)
     if bucket is None:
-        client = storage.Client(project_id)
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(auth_json)
+        client = storage.Client(project_id,credentials)
         bucket = client.get_bucket(bucket_id)
         buckets[project_id][bucket_id] = bucket
 

--- a/thumbor_cloud_storage/result_storages/cloud_storage.py
+++ b/thumbor_cloud_storage/result_storages/cloud_storage.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from os.path import join
 from gcloud import storage
+from oauth2client.service_account import ServiceAccountCredentials
 
 from thumbor.result_storages import BaseStorage
 from thumbor.utils import logger
@@ -32,7 +33,9 @@ class Storage(BaseStorage):
         if not parent.bucket:
             bucket_id  = self.context.config.get("RESULT_STORAGE_CLOUD_STORAGE_BUCKET_ID")
             project_id = self.context.config.get("RESULT_STORAGE_CLOUD_STORAGE_PROJECT_ID")
-            client = storage.Client(project_id)
+            auth_json = self.context.config.get("RESULT_STORAGE_CLOUD_STORAGE_AUTH_JSON")
+            credentials = ServiceAccountCredentials.from_json_keyfile_name(auth_json)
+            client = storage.Client(project_id, credentials)
             parent.bucket = client.get_bucket(bucket_id)
         return parent.bucket
 


### PR DESCRIPTION
It looks like the data format returned by blob.updated has changed. Made datetime.now() timezone aware.

Error example:

> 2016-04-07 07:57:12 thumbor:ERROR [RESULT_STORAGE] getting from thumbor/v2/un/sa/unsafe/100x0/TuxOSX.png
> 2016-04-07 07:57:12 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
>   File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 282, in wrapper
>     yielded = next(result)
>   File "/usr/lib64/python2.7/site-packages/thumbor/handlers/**init**.py", line 63, in execute_image_operations
>     result = yield gen.maybe_future(self.context.modules.result_storage.get())
>   File "/usr/lib64/python2.7/site-packages/thumbor/result_storages/cloud_storage.py", line 76, in get
>     if not blob or self.is_expired(blob):
>   File "/usr/lib64/python2.7/site-packages/thumbor/result_storages/cloud_storage.py", line 101, in is_expired
>     timediff = datetime.now() - blob.updated
> TypeError: can't subtract offset-naive and offset-aware datetimes

Thank you.
