### PR TITLE
blob.updated returns timezone aware data.

### DIFF
--- a/thumbor_cloud_storage/result_storages/cloud_storage.py
+++ b/thumbor_cloud_storage/result_storages/cloud_storage.py
@@ -6,6 +6,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 
+import pytz
 from datetime import datetime
 
 from os.path import join
@@ -92,7 +93,7 @@ class Storage(BaseStorage):
         if expire_in_seconds is None or expire_in_seconds == 0:
             return False
 
-        timediff = datetime.now() - blob.updated 
+        timediff = datetime.now(pytz.utc) - blob.updated
         return timediff.seconds > expire_in_seconds
 
     def last_updated(self):


### PR DESCRIPTION
It looks like the data format returned by blob.updated has changed. Made datetime.now() timezone aware.

Error example:

2016-04-07 07:57:12 thumbor:ERROR [RESULT_STORAGE] getting from thumbor/v2/un/sa/unsafe/100x0/TuxOSX.png
2016-04-07 07:57:12 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 282, in wrapper
yielded = next(result)
File "/usr/lib64/python2.7/site-packages/thumbor/handlers/init.py", line 63, in execute_image_operations
result = yield gen.maybe_future(self.context.modules.result_storage.get())
File "/usr/lib64/python2.7/site-packages/thumbor/result_storages/cloud_storage.py", line 76, in get
if not blob or self.is_expired(blob):
File "/usr/lib64/python2.7/site-packages/thumbor/result_storages/cloud_storage.py", line 101, in is_expired
timediff = datetime.now() - blob.updated
TypeError: can't subtract offset-naive and offset-aware datetimes
Thank you.
