### PR TITLE
Update gcloud version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 REQUIREMENTS = [
   "thumbor==5.0.3",
-  "gcloud==0.7.1",
+  "gcloud==0.13.0",
   "protorpc==0.10.0",
 ]
 


### PR DESCRIPTION
Hi,

I was having an issue when deploying to docker..and fixed the error by updating the gcloud dependency to the latest version. I don't know if you can reproduce the same error ? Issues on the repo are disabled so i just created a PR :-)

Pip errored when I was doing the following:

In a docker container: (python:2)

```
git clone https://github.com/Superbalist/thumbor-cloud-storage 
cd thumbor-cloud-storage 
pip install .

root@d9b756b58211:/thumbor-cloud-storage# pip install .
Processing /thumbor-cloud-storage
Collecting thumbor==5.0.3 (from thumbor-cloud-storage==2.0.1)
  Using cached thumbor-5.0.3.tar.gz
Collecting gcloud==0.7.1 (from thumbor-cloud-storage==2.0.1)
  Using cached gcloud-0.7.1.tar.gz
Collecting protorpc==0.10.0 (from thumbor-cloud-storage==2.0.1)
  Using cached protorpc-0.10.0.zip
Requirement already satisfied (use --upgrade to upgrade): tornado<5.0.0,>=4.1.0 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): pyCrypto>=2.1.0 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): pycurl<7.20.0,>=7.19.0 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Collecting Pillow<3.0.0,>=2.7.0 (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
  Using cached Pillow-2.9.0.zip
Requirement already satisfied (use --upgrade to upgrade): derpconf>=0.2.0 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): python-magic>=0.4.3 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): pexif<1.0,>=0.15 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): statsd>=3.0.1 in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): libthumbor in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Requirement already satisfied (use --upgrade to upgrade): futures in /usr/local/lib/python2.7/site-packages (from thumbor==5.0.3->thumbor-cloud-storage==2.0.1)
Collecting google-apitools (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1)
  Using cached google_apitools-0.5.2-py2-none-any.whl
Collecting httplib2>=0.9.1 (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1)
  Using cached httplib2-0.9.2.zip
Collecting oauth2client>=1.4.6 (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1)
  Using cached oauth2client-2.0.2.tar.gz
Collecting protobuf==3.0.0-alpha-1 (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1)
  Could not find a version that satisfies the requirement protobuf==3.0.0-alpha-1 (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1) (from versions: 2.0.0b0, 2.0.3, 2.3.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, 3.0.0a2, 3.0.0a3, 3.0.0b1, 3.0.0b1.post1, 3.0.0b1.post2, 3.0.0b2, 3.0.0b2.post1, 3.0.0b2.post2)
No matching distribution found for protobuf==3.0.0-alpha-1 (from gcloud==0.7.1->thumbor-cloud-storage==2.0.1)
```
